### PR TITLE
STOR-21033 storedge-api-client-php:Medium: nformation Exposure - Server Error Message

### DIFF
--- a/src/RedNovaLabs/Storedge/SDK.php
+++ b/src/RedNovaLabs/Storedge/SDK.php
@@ -233,7 +233,7 @@ class SDK {
       try {
         return $this->get($base_url . $facility_uuid . '/leads' . $query);
       } catch (BaseException $e) {
-        echo $e->getMessage();
+        $this->logErrorAndShowMessage($e);
       }
     }
 
@@ -242,7 +242,7 @@ class SDK {
       try {
         return $this->post($base_url . $facility_uuid . '/leads', $data);
       } catch (BaseException $e) {
-        echo $e->getMessage();
+        $this->logErrorAndShowMessage($e);
       }
     }
 
@@ -251,7 +251,7 @@ class SDK {
       try {
         return $this->delete($base_url . $facility_uuid . '/leads/' . $lead_uuid, $params);
       } catch (BaseException $e) {
-        echo $e->getMessage();
+        $this->logErrorAndShowMessage($e);
       }
 
     }
@@ -262,7 +262,7 @@ class SDK {
       try {
         return $this->patch($base_url . $facility_uuid . '/tenants/' . $tenant_uuid, $data);
       } catch (BaseException $e) {
-        echo $e->getMessage();
+        $this->logErrorAndShowMessage($e);
       }
 
     }
@@ -272,7 +272,7 @@ class SDK {
       try {
         return $this->put($base_url . $facility_uuid . '/tenants/' . $tenant_uuid, $data);
       } catch (BaseException $e) {
-        echo $e->getMessage();
+        $this->logErrorAndShowMessage($e);
       }
     }
 
@@ -281,7 +281,7 @@ class SDK {
       try {
         return $this->post($base_url . $facility_uuid . '/tenants/' . $tenant_uuid . '/sign_up', $data);
       } catch (BaseException $e) {
-        echo $e->getMessage();
+        $this->logErrorAndShowMessage($e);
       }
     }
 
@@ -290,7 +290,7 @@ class SDK {
       try {
         return $this->put($base_url . $facility_uuid . '/tenants/' . $tenant_uuid . '/change_password', $data);
       } catch (BaseException $e) {
-        echo $e->getMessage();
+        $this->logErrorAndShowMessage($e);
       }
     }
 
@@ -304,7 +304,7 @@ class SDK {
       try {
         return $this->get($base_url . $facility_uuid . '/unit_groups' . $query);
       } catch (BaseException $e) {
-        echo $e->getMessage();
+        $this->logErrorAndShowMessage($e);
       }
     }
 
@@ -317,7 +317,7 @@ class SDK {
       try {
         return $this->get($base_url . $facility_uuid . '/unit_groups/' . $unit_group_uuid . $query);
       } catch (BaseException $e) {
-        echo $e->getMessage();
+        $this->logErrorAndShowMessage($e);
       }
     }
 
@@ -330,7 +330,7 @@ class SDK {
       try {
         return $this->get($base_url . $facility_uuid . '/unit_groups/' . $unit_group_uuid . '/units' . $query);
       } catch (BaseException $e) {
-        echo $e->getMessage();
+        $this->logErrorAndShowMessage($e);
       }
     }
 
@@ -344,7 +344,7 @@ class SDK {
       try {
         return $this->get($base_url . $facility_uuid . '/units' . $query);
       } catch (BaseException $e) {
-        echo $e->getMessage();
+        $this->logErrorAndShowMessage($e);
       }
     }
 
@@ -357,7 +357,7 @@ class SDK {
       try {
         return $this->get($base_url . $facility_uuid . '/units/available' . $query);
       } catch (BaseException $e) {
-        echo $e->getMessage();
+        $this->logErrorAndShowMessage($e);
       }
     }
 
@@ -370,8 +370,14 @@ class SDK {
       try {
         return $this->get($base_url . $facility_uuid . '/units/' . $unit_uuid . $query);
       } catch (BaseException $e) {
-        echo $e->getMessage();
+        $this->logErrorAndShowMessage($e);
       }
+    }
+
+    private function logErrorAndShowMessage($e)
+    {
+      error_log($e->getMessage());
+      echo("Something went wrong with API request. Check error log for details.\n");
     }
 
 }


### PR DESCRIPTION
Jira Ticket [STOR-21033](https://sparefoot.atlassian.net/browse/STOR-21033)

**Flippers**
* `flipper_fms_feature_name`

**Related PRs**
* Link to PRs from other projects

## Purpose
<!-- A brief description of these changes and the problem it solves. -->
Fix Information Exposure - Server Error Message vulnerability

## Technical Summary
<!-- A summary of the technical changes that highlights any significant or impactful changes. -->
Using error_log to write error to log.

<!-- REMINDER: If you use copilot's summary, please verify that it is accurate! -->
<!-- copilot:summary -->

<!-- TIP: Only use copilot's walkthrough for really large PRs. -->
<!-- copilot:walkthrough -->

## Merge Checklist
<!-- The [Jira Workflow Process](https://sparefoot.atlassian.net/wiki/spaces/SEDEV/pages/1787035678/Jira+Workflow+Process) and [PR Expectations](https://sparefoot.atlassian.net/wiki/spaces/SEDEV/pages/3845521737/PR+Expectations) have more detailed explanations and expectations -->

- [ ] I have included new or updated tests for code logic changes
- [ ] I have confirmed ticket's AC is up to date and these changes fulfill all of them
- [ ] I have demoed UI changes to the Product Owner and Designer
- [x] I have added specific manual testing instructions to the ticket
- [ ] I have added or updated applicable documentation
- [ ] When I squash and merge this PR, I will remove insignificant commit messages

## Screenshots
<!-- If there are UI changes, include before & after screenshots. -->
<!--
<details><summary>Click to expand</summary>

</details>
-->
Verify in local development
Running samples.php in terminal 
It needs to edit config as following to match with local configration

```
  $base_url = 'https://localable.io:3010/v1/';
  $api_key  = 'sesc'; // get in FMS data
  $api_secret = 'sesc'; // get in FMS data

  // Sample uuids
  $facility_uuid = '9df67dc0-293c-0135-3eed-10ddb1b10572'; // get in FMS data
  $unit_uuid = '9e017df0-293c-0135-3eed-10ddb1b10572'; // get in FMS data
  $tenant_uuid = 'b0948532-f8e6-46ce-b587-5d0218478506'; // get in FMS data
  $lead_uuid = '16a4a566-c3da-42d0-a73e-fbedc4dfdb33'; // get in FMS data
  $unit_group_uuid = '3623b02f-e41c-4f21-8db1-c9a79c73ae85'; // get in FMS data

```
<img width="1904" height="1135" alt="STOR-21033-php-sample" src="https://github.com/user-attachments/assets/1b34d023-e4b5-4e26-ae73-0342f9373e07" />

Snyk code test
<img width="1904" height="1135" alt="STOR-21033-snyk-code-test" src="https://github.com/user-attachments/assets/cde42ab4-eeb0-4a1d-98ec-6570ac8162cd" />

